### PR TITLE
Set `pnum` to 0 if no passwords exposed

### DIFF
--- a/hibpwned/__init__.py
+++ b/hibpwned/__init__.py
@@ -457,10 +457,11 @@ class Pwned:
         if resp.status_code == 200:
             hash_list = resp.text.splitlines()
             for item in hash_list:
+                if item[0:35] != hexdig[5:]:
+                    pnum = 0
+            for item in hash_list:
                 if item[0:35] == hexdig[5:]:
                     pnum = item[36:]
-                else:
-                    pnum = 0
             return pnum
         return resp.status_code
 

--- a/hibpwned/__init__.py
+++ b/hibpwned/__init__.py
@@ -452,14 +452,15 @@ class Pwned:
         hexdig = hash_object.hexdigest()
         hexdig = hexdig.upper()
         hsh = hexdig[:5]
+        pnum = '0'
         resp = requests.get(url + hsh, headers=self.header)
         _check(resp)
         if resp.status_code == 200:
             hash_list = resp.text.splitlines()
             for item in hash_list:
                 if item[0:35] == hexdig[5:]:
-                    return item[36:]
-            return 0
+                    pnum = item[36:]
+            return pnum
         return resp.status_code
 
     def search_hashes(self, hsh: str) -> Union[int, str]:

--- a/hibpwned/__init__.py
+++ b/hibpwned/__init__.py
@@ -457,12 +457,9 @@ class Pwned:
         if resp.status_code == 200:
             hash_list = resp.text.splitlines()
             for item in hash_list:
-                if item[0:35] != hexdig[5:]:
-                    pnum = 0
-            for item in hash_list:
                 if item[0:35] == hexdig[5:]:
-                    pnum = item[36:]
-            return pnum
+                    return item[36:]
+            return 0
         return resp.status_code
 
     def search_hashes(self, hsh: str) -> Union[int, str]:

--- a/hibpwned/__init__.py
+++ b/hibpwned/__init__.py
@@ -459,6 +459,8 @@ class Pwned:
             for item in hash_list:
                 if item[0:35] == hexdig[5:]:
                     pnum = item[36:]
+                else:
+                    pnum = 0
             return pnum
         return resp.status_code
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """Setup file"""
 from setuptools import setup  # type: ignore
 
-VERSION = "1.3.4"
+VERSION = "1.3.5"
 
 with open("README.md", "r", encoding="utf-8") as fh:
     LONG_DESCRIPTION = fh.read()

--- a/test.py
+++ b/test.py
@@ -15,6 +15,7 @@
 """
 
 import unittest
+import random
 from unittest import mock
 from typing import Optional, Union, List, Dict, Any
 import requests
@@ -62,6 +63,17 @@ def mocked_requests_get(*args: Any, **kwargs: Any) -> Any:
     return MockResponse(None, 404)
 
 
+def password_generator() -> str:
+    """Generate a unique randomish password."""
+    password = ''
+    for _ in range(random.randint(25, 30)):
+        rand_int = random.randint(97, 97 + 26 - 1)
+        if random.randint(0, 1):
+            rand_int = rand_int - 32
+        password += chr(rand_int)
+    return password
+
+
 class TestApiCalls(unittest.TestCase):
     """Test all module API calls."""
     email: str = "test@example.com"
@@ -74,8 +86,10 @@ class TestApiCalls(unittest.TestCase):
     def test_search_password(self) -> None:
         """Test search_password function."""
         weak = self.pwned.search_password("password")
+        strong = self.pwned.search_password(password_generator())
         if isinstance(weak, str):
             self.assertTrue(weak.isdigit())
+        self.assertEqual(strong, '0')
 
     def test_single_breach(self) -> None:
         """Test single_breach function."""


### PR DESCRIPTION
I'm writing [a small program](https://github.com/th0mcat/hibpwned-console/) that interacts with `hibpwned` to output results to a terminal.  Right now, if I try to check a password that has no known HIBP breaches, the program errors out with the following:

```
Traceback (most recent call last):
  File "/<path>/test.py", line 49, in <module>
    main()
  File "/<path>/thomcat_test.py", line 41, in main
    check_pass_str = hibpconsole.search_password(check_pass)
  File "/home/coder/projects/opsdroid-hibp/hibpwned/__init__.py", line 462, in search_password
    return pnum
UnboundLocalError: local variable 'pnum' referenced before assignment
```

I believe some output should be returned even if no breaches have been found.  Adding these 2 lines of code to __init__.py fixes this.